### PR TITLE
Adding status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Language Server Indexing Format Implementation for JSonnet
+# JSonnet LSIF indexer ![](https://img.shields.io/badge/status-development-yellow)
 
 🚨 This implementation is still in very early stage and follows the latest LSIF specification closely.
 


### PR DESCRIPTION
Status badge helps inform users of the state of the tool, the badge should match status listed in: https://lsif.dev/