### PR TITLE
Remove use of ioutil package

### DIFF
--- a/cmd/lsif-jsonnet/main.go
+++ b/cmd/lsif-jsonnet/main.go
@@ -9,10 +9,11 @@ import (
 	"path/filepath"
 	"strings"
 
-	flag "github.com/spf13/pflag"
 	"lsif-jsonnet/dumper"
 	"lsif-jsonnet/protocol"
 	"lsif-jsonnet/refs"
+
+	flag "github.com/spf13/pflag"
 )
 
 const version = "1.0.0"

--- a/refs/listener.go
+++ b/refs/listener.go
@@ -2,11 +2,11 @@ package refs
 
 import (
 	"fmt"
-	"io/ioutil"
 
-	"github.com/antlr/antlr4/runtime/Go/antlr"
 	"lsif-jsonnet/parser"
 	"lsif-jsonnet/types"
+
+	"github.com/antlr/antlr4/runtime/Go/antlr"
 )
 
 type Listener struct {
@@ -21,7 +21,7 @@ type Listener struct {
 }
 
 func ParseFile(path string, pathResolver *PathResolver) (*Listener, error) {
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Removes usage of the deprecated ioutil package as described [here](https://golang.org/doc/go1.16#ioutil)

[_Created by Sourcegraph batch change `rslade/deprecate-ioutil`._](https://k8s.sgdev.org/users/rslade/batch-changes/deprecate-ioutil)