### PR TITLE
chore: use report-job-failure from sourcegraph/workflows in github actions

### DIFF
--- a/.github/workflows/pr-auditor.yml
+++ b/.github/workflows/pr-auditor.yml
@@ -24,5 +24,5 @@ jobs:
   report_failure:
     needs: check-pr
     if: ${{ failure() }}
-    uses: sourcegraph/sourcegraph/.github/workflows/report-job-failure.yml@main
+    uses: sourcegraph/workflows/.github/workflows/report-job-failure.yml@main
     secrets: inherit


### PR DESCRIPTION
This PR updates GitHub actions that report failures via sentry to use the workflow from sourcegraph/workflows

Part of DINF-218

[_Created by Sourcegraph batch change `burmudar/github-actions-update-report-failure`._](https://sourcegraph.sourcegraph.com/users/burmudar/batch-changes/github-actions-update-report-failure)